### PR TITLE
Enable log-prob output from ActorMPC

### DIFF
--- a/ACMPC/trainer.py
+++ b/ACMPC/trainer.py
@@ -111,12 +111,8 @@ def update_step() -> None:
     history, action, reward, next_state, done = replay_buffer.sample(BATCH_SIZE)
     dummy_U = torch.zeros(HORIZON, NU, device=DEVICE)
     with torch.no_grad():                                              # target-path
-        next_a, next_logp = [], []
-        for s in next_state:                                           # loop finché
-            a_i, lp_i = actor.get_action(s, dummy_U)                   # get_action
-            next_a.append(a_i), next_logp.append(lp_i)                 # non è batch-safe
-        next_a     = torch.stack(next_a)                               # (B, nu)
-        next_logp  = torch.stack(next_logp).unsqueeze(1)               # (B, 1)
+        next_a, next_logp = actor.get_action(next_state, dummy_U)
+        next_logp = next_logp.unsqueeze(1)
 
         next_hist  = torch.roll(history, shifts=-1, dims=1)
         next_hist[:, -1, :] = torch.cat([next_state, next_a], dim=-1)
@@ -137,12 +133,8 @@ def update_step() -> None:
     critic_scaler.step(critic_optimizer)
     critic_scaler.update()
     s_t = history[:, -1, :NX]                                          # (B, nx)
-    a_pi, logp_pi = [], []
-    for s in s_t:                                                      # idem, non-batch
-        a_i, lp_i = actor.get_action(s, dummy_U, deterministic=False)
-        a_pi.append(a_i), logp_pi.append(lp_i)
-    a_pi   = torch.stack(a_pi)                                         # (B, nu)
-    logp_pi = torch.stack(logp_pi).unsqueeze(1)                        # (B, 1)
+    a_pi, logp_pi = actor.get_action(s_t, dummy_U, deterministic=False)
+    logp_pi = logp_pi.unsqueeze(1)
     hist_pi = history.clone()
     hist_pi[:, -1, NX:] = a_pi
 

--- a/tests/test_actor_grad.py
+++ b/tests/test_actor_grad.py
@@ -56,7 +56,7 @@ def test_actor_grad_flow():
     # stato batch-1
     x = torch.randn(nx, device=device, requires_grad=True)
 
-    action = actor(x)                # grad through MPC + policy
+    action, _ = actor(x)             # grad through MPC + policy
 
     # fittizia loss quadratica sull'azione
     loss = (action ** 2).sum()

--- a/tests/test_actor_grad_warm.py
+++ b/tests/test_actor_grad_warm.py
@@ -67,10 +67,10 @@ def test_actor_grad_flow_warm():
     x = torch.randn(nx, device=device, requires_grad=True)
 
     # ── Primo passaggio: serve solo a riempire U_prev per warm-start ──
-    _ = actor(x)
+    _ , _ = actor(x)
 
     # ── Secondo passaggio (con warm-start) ──
-    action = actor(x)
+    action, _ = actor(x)
 
     # Loss fittizia
     loss = (action ** 2).sum()


### PR DESCRIPTION
## Summary
- extend `ActorMPC.get_action` with `U_init` and `deterministic` options
- return both action and log-probability
- vectorize calls in `trainer.py`
- update actor gradient tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68750f1570ac8326aeab670963cd9f05