### PR TITLE
Fix exports in DifferentialMPC

### DIFF
--- a/DifferentialMPC/__init__.py
+++ b/DifferentialMPC/__init__.py
@@ -3,3 +3,12 @@ from .controller import DifferentiableMPCController
 from .controller import GradMethod
 from .utils import pnqp
 from .utils import batched_jacobian, jacobian_finite_diff_batched
+
+__all__ = [
+    "GeneralQuadCost",
+    "DifferentiableMPCController",
+    "GradMethod",
+    "pnqp",
+    "batched_jacobian",
+    "jacobian_finite_diff_batched",
+]


### PR DESCRIPTION
## Summary
- add module exports to `DifferentialMPC.__init__`

## Testing
- `ruff check DifferentialMPC/__init__.py --isolated`
- `pytest -c /dev/null -q`

------
https://chatgpt.com/codex/tasks/task_e_68760bb9a7c48326bcd67a87864c43db