### PR TITLE
Add advantage normalization and entropy bonus

### DIFF
--- a/ACMPC/actor.py
+++ b/ACMPC/actor.py
@@ -90,7 +90,13 @@ class ActorMPC(nn.Module):
         return log_std
 
     # ------------------------------------------------------------------
-    def get_action(self, x: Tensor, U_init: Tensor | None = None, deterministic: bool | None = None):
+    def get_action(
+        self,
+        x: Tensor,
+        U_init: Tensor | None = None,
+        deterministic: bool | None = None,
+        return_entropy: bool = False,
+    ):
         single = x.ndim == 1
         if single:
             x = x.unsqueeze(0)
@@ -117,9 +123,13 @@ class ActorMPC(nn.Module):
         else:
             action = dist.rsample()
         log_prob = dist.log_prob(action).sum(dim=-1)
+        entropy = dist.entropy().sum(dim=-1)
         if single:
             action = action.squeeze(0)
             log_prob = log_prob.squeeze(0)
+            entropy = entropy.squeeze(0)
+        if return_entropy:
+            return action, log_prob, entropy
         return action, log_prob
 
     # alias for nn.Module forward

--- a/ACMPC/training_loop.py
+++ b/ACMPC/training_loop.py
@@ -6,42 +6,97 @@ from .actor import ActorMPC
 from .critic_transformer import CriticTransformer
 
 
-def rollout(env, actor: ActorMPC, horizon: int):
+def rollout(env, actor: ActorMPC, critic: CriticTransformer, horizon: int):
     states = []
     actions = []
     rewards = []
+    log_probs = []
+    entropies = []
+    values = []
     state = env.reset()
+    hist = torch.zeros(1, critic.history_len, actor.nx + actor.nu, device=state.device)
+    pred = torch.zeros(1, critic.pred_horizon, actor.nx + actor.nu, device=state.device)
     for _ in range(horizon):
-        action, _ = actor(state)
+        action, log_p, ent = actor(state, return_entropy=True)
+        value = critic(state.unsqueeze(0), action.unsqueeze(0), hist, pred).squeeze(0)
         next_state, reward, done = env.step(action)
         states.append(state)
         actions.append(action)
         rewards.append(torch.tensor([reward], dtype=torch.float32, device=state.device))
+        log_probs.append(log_p)
+        entropies.append(ent)
+        values.append(value)
         state = next_state
         if done:
             state = env.reset()
-    return torch.stack(states), torch.stack(actions), torch.stack(rewards)
+    with torch.no_grad():
+        last_action, _ = actor(state)
+        next_value = critic(state.unsqueeze(0), last_action.unsqueeze(0), hist, pred).squeeze(0)
+    return (
+        torch.stack(states),
+        torch.stack(actions),
+        torch.stack(rewards),
+        torch.stack(log_probs),
+        torch.stack(entropies),
+        torch.stack(values),
+        next_value,
+    )
 
 
-def train(env, actor: ActorMPC, critic: CriticTransformer, steps: int = 100):
+def _compute_gae(rewards: torch.Tensor, values: torch.Tensor, next_value: torch.Tensor, gamma: float, lam: float):
+    advantages = torch.zeros_like(rewards)
+    returns = torch.zeros_like(rewards)
+    gae = 0.0
+    v_next = next_value
+    for t in reversed(range(rewards.shape[0])):
+        delta = rewards[t] + gamma * v_next - values[t]
+        gae = delta + gamma * lam * gae
+        advantages[t] = gae
+        returns[t] = gae + values[t]
+        v_next = values[t]
+    return returns, advantages
+
+
+def train(
+    env,
+    actor: ActorMPC,
+    critic: CriticTransformer,
+    steps: int = 100,
+    horizon: int = 10,
+    gamma: float = 0.99,
+    lam: float = 0.95,
+    entropy_coef: float = 0.0,
+    scheduler: optim.lr_scheduler._LRScheduler | None = None,
+):
     actor_opt = optim.Adam(actor.parameters(), lr=3e-4)
     critic_opt = optim.Adam(critic.parameters(), lr=3e-4)
 
     for _ in range(steps):
-        states, actions, rewards = rollout(env, actor, horizon=10)
-        # simple cumulative reward
-        returns = rewards.flip(0).cumsum(0).flip(0)
-        critic_in_hist = torch.zeros(1, critic.history_len, actor.nx + actor.nu, device=states.device)
-        pred = torch.zeros(1, critic.pred_horizon, actor.nx + actor.nu, device=states.device)
-        values = critic(states[-1].unsqueeze(0), actions[-1].unsqueeze(0), critic_in_hist, pred)
-        advantages = returns.sum() - values
+        (
+            states,
+            actions,
+            rewards,
+            log_probs,
+            entropies,
+            values,
+            next_value,
+        ) = rollout(env, actor, critic, horizon=horizon)
 
-        actor_loss = -advantages
-        critic_loss = advantages.pow(2)
+        returns, advantages = _compute_gae(
+            rewards.squeeze(-1), values, next_value, gamma=gamma, lam=lam
+        )
+        adv_norm = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
+
+        actor_loss = -(log_probs * adv_norm.detach()).mean()
+        if entropy_coef:
+            actor_loss -= entropy_coef * entropies.mean()
+        critic_loss = torch.nn.functional.mse_loss(values, returns)
 
         actor_opt.zero_grad()
-        actor_loss.backward(retain_graph=True)
+        actor_loss.backward()
         actor_opt.step()
+        if scheduler is not None:
+            scheduler.step()
 
         critic_opt.zero_grad()
         critic_loss.backward()


### PR DESCRIPTION
## Summary
- extend `rollout` to record critic values and log probs
- compute generalized advantage estimation
- normalize advantages and add optional entropy bonus
- expose entropy from `ActorMPC.get_action`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68761e65547083269500423f6ed8a944