### PR TITLE
Add seed helper for reproducible examples

### DIFF
--- a/ACMPC/training_loop.py
+++ b/ACMPC/training_loop.py
@@ -1,6 +1,7 @@
 """Minimal PPO training loop for ActorMPC and CriticTransformer."""
 import torch
 import torch.optim as optim
+from utils import seed_everything
 
 from .actor import ActorMPC
 from .critic_transformer import CriticTransformer
@@ -23,7 +24,8 @@ def rollout(env, actor: ActorMPC, horizon: int):
     return torch.stack(states), torch.stack(actions), torch.stack(rewards)
 
 
-def train(env, actor: ActorMPC, critic: CriticTransformer, steps: int = 100):
+def train(env, actor: ActorMPC, critic: CriticTransformer, steps: int = 100, seed: int = 0):
+    seed_everything(seed)
     actor_opt = optim.Adam(actor.parameters(), lr=3e-4)
     critic_opt = optim.Adam(critic.parameters(), lr=3e-4)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Alternatively a convenience entry point is installed:
 ac-mpc-examples 03_demo_cartpole_regulationAC
 ```
 
+## Reproducibility
+
+A helper `utils.seed_everything(seed)` seeds Python's `random`, NumPy and
+PyTorch for deterministic runs. All example scripts and the training loop call
+this function with seed `0` by default. Pass a different value to vary the
+random initialization.
+
 ## Testing
 
 After installing the development extras simply run:

--- a/examples/01_demo_linear_tracking.py
+++ b/examples/01_demo_linear_tracking.py
@@ -3,6 +3,7 @@ import time
 import torch
 import numpy as np
 import matplotlib.pyplot as plt
+from utils import seed_everything
 
 # Importa le classi principali dal tuo nuovo pacchetto
 from DifferentialMPC import DifferentiableMPCController, GeneralQuadCost
@@ -22,6 +23,7 @@ def f_dyn_jac_linear(x, u, dt):
 
 
 def main():
+    seed_everything(0)
     torch.set_default_dtype(torch.double)
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     print(f"Esecuzione su dispositivo: {device}")

--- a/examples/02_demo_cartpole_regulation.py
+++ b/examples/02_demo_cartpole_regulation.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import gym
 import os
 from contextlib import redirect_stdout
+from utils import seed_everything
 
 # Importa le classi principali dal pacchetto
 from DifferentialMPC import DifferentiableMPCController, GeneralQuadCost
@@ -55,6 +56,7 @@ def f_cartpole(x: torch.Tensor, u: torch.Tensor, dt: float, p: CartPoleParams) -
 
 # ======================== ROUTINE PRINCIPALE ========================
 def main():
+    seed_everything(0)
     # --- Configurazione Globale ---
     torch.set_default_dtype(torch.float64)
     DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -108,7 +110,6 @@ def main():
 
     # --- Batch di stati iniziali casuali (vicino al punto di instabilità) ---
     base_state = torch.tensor([0.0, 0.0, 0.2, 0.0], device=DEVICE)  # Partenza con palo inclinato
-    torch.manual_seed(0)
     x0 = base_state + torch.tensor([1.0, 1.0, 0.5, 0.5], device=DEVICE) * torch.randn(BATCH_SIZE, nx, device=DEVICE)
 
     # --- Esecuzione Simulazione ---

--- a/examples/03_demo_cartpole_regulationAC.py
+++ b/examples/03_demo_cartpole_regulationAC.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import gym
 import os
 from contextlib import redirect_stdout
+from utils import seed_everything
 from DifferentialMPC import DifferentiableMPCController, GeneralQuadCost, GradMethod
 
 LOG_STD_MAX = 2
@@ -144,6 +145,7 @@ class ActorMPC(nn.Module):
 
 # --- Sanity Check ---
 if __name__ == '__main__':
+    seed_everything(0)
     torch.set_default_dtype(torch.float64)
     env = CartPoleEnv(device="cpu")
     state = env.reset()

--- a/examples/03_demo_unicycle_tracking.py
+++ b/examples/03_demo_unicycle_tracking.py
@@ -3,6 +3,7 @@ import time
 import torch
 import numpy as np
 import matplotlib.pyplot as plt
+from utils import seed_everything
 
 # Importa le classi principali dal pacchetto
 from DifferentialMPC import DifferentiableMPCController, GeneralQuadCost
@@ -43,6 +44,7 @@ def f_dyn_jac_unicycle(state: torch.Tensor, control: torch.Tensor, dt: float) ->
 
 # ======================== ROUTINE PRINCIPALE ========================
 def main():
+    seed_everything(0)
     # --- Configurazione Globale ---
     torch.set_default_dtype(torch.double)
     DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/examples/04_minimal_actor.py
+++ b/examples/04_minimal_actor.py
@@ -2,6 +2,7 @@
 import torch
 from ACMPC import ActorMPC, CriticTransformer
 from DifferentialMPC import DifferentiableMPCController
+from utils import seed_everything
 
 
 def dummy_dyn(x, u, dt):
@@ -24,6 +25,7 @@ class DummyEnv:
 
 
 def main():
+    seed_everything(0)
     device = torch.device("cpu")
     class Policy(torch.nn.Module):
         def __init__(self):

--- a/examples/05_double_integrator_ac_vs_baseline.py
+++ b/examples/05_double_integrator_ac_vs_baseline.py
@@ -6,6 +6,7 @@ from tqdm import trange
 
 from DifferentialMPC import DifferentiableMPCController, GeneralQuadCost
 from ACMPC import ActorMPC, CriticTransformer, training_loop
+from utils import seed_everything
 
 
 def f_dyn_linear(x: torch.Tensor, u: torch.Tensor, dt: float) -> torch.Tensor:
@@ -99,7 +100,7 @@ def train_ac(env: DoubleIntegratorEnv, steps: int = 1000, horizon: int = 20):
     rewards = []
     q_grads = []
     for _ in trange(steps, desc="training", leave=False):
-        training_loop.train(env, actor, critic, steps=1)
+        training_loop.train(env, actor, critic, steps=1, seed=0)
         with torch.no_grad():
             q_grad = actor.q_raw.grad.abs().mean().item() if actor.q_raw.grad is not None else 0.0
         q_grads.append(q_grad)
@@ -134,6 +135,7 @@ def evaluate_actor(env: DoubleIntegratorEnv, actor: ActorMPC, episodes: int = 20
 
 
 def main():
+    seed_everything(0)
     torch.set_default_dtype(torch.double)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     env = DoubleIntegratorEnv(device=device)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,14 @@
+import random
+import numpy as np
+import torch
+
+
+def seed_everything(seed: int) -> None:
+    """Seed Python, NumPy and torch random generators."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+


### PR DESCRIPTION
## Summary
- add `utils.seed_everything` for deterministic execution
- call `seed_everything` from training loop and all example scripts
- mention reproducibility in the README

## Testing
- `pip install -e .[dev,examples]` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pytest -q` *(failed: torch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68761e6ca0e48326b69b0afb483ecdbf