### PR TITLE
Add regression tests for actor and critic

### DIFF
--- a/tests/test_actor_get_action.py
+++ b/tests/test_actor_get_action.py
@@ -1,0 +1,48 @@
+import torch
+import torch.nn as nn
+from ACMPC import ActorMPC
+
+
+def f_lin(x, u, dt):
+    return x + dt * u
+
+
+class DummyPolicy(nn.Module):
+    def __init__(self, nx, nu):
+        super().__init__()
+        self.fc = nn.Linear(nx, 2 * nu)
+
+    def forward(self, x):
+        mu, log_std = self.fc(x).chunk(2, dim=-1)
+        return mu, log_std
+
+
+def test_get_action_shape_and_reproducibility(device):
+    torch.set_default_dtype(torch.double)
+    nx = nu = 1
+    dt = 0.1
+    policy = DummyPolicy(nx, nu).to(device).double()
+    actor = ActorMPC(
+        nx, nu, horizon=3, dt=dt, f_dyn=f_lin, policy_net=policy, device=str(device)
+    ).to(device)
+    actor.train()
+
+    x_single = torch.randn(nx, device=device)
+    torch.manual_seed(0)
+    a1, lp1 = actor.get_action(x_single)
+    torch.manual_seed(0)
+    a2, lp2 = actor.get_action(x_single)
+    assert a1.shape == (nu,)
+    assert lp1.shape == ()
+    assert torch.allclose(a1, a2)
+    assert torch.allclose(lp1, lp2)
+
+    x_batch = torch.randn(4, nx, device=device)
+    torch.manual_seed(1)
+    ab1, lpb1 = actor.get_action(x_batch)
+    torch.manual_seed(1)
+    ab2, lpb2 = actor.get_action(x_batch)
+    assert ab1.shape == (4, nu)
+    assert lpb1.shape == (4,)
+    assert torch.allclose(ab1, ab2)
+    assert torch.allclose(lpb1, lpb2)

--- a/tests/test_critic_forward.py
+++ b/tests/test_critic_forward.py
@@ -1,0 +1,26 @@
+import torch
+from ACMPC import CriticTransformer
+
+
+def test_critic_forward_regression():
+    prev_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float32)
+    try:
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            critic = CriticTransformer(2, 1, history_len=3, pred_horizon=2).double()
+            critic.eval()
+
+            cs = torch.randn(1, 2, dtype=torch.double)
+            ca = torch.randn(1, 1, dtype=torch.double)
+            hist = torch.randn(1, 3, 3, dtype=torch.double)
+            pred = torch.randn(1, 2, 3, dtype=torch.double)
+
+            with torch.no_grad():
+                q = critic(cs, ca, hist, pred)
+    finally:
+        torch.set_default_dtype(prev_dtype)
+
+    expected = torch.tensor([0.010050535202026367], dtype=torch.double)
+    assert q.shape == (1,)
+    assert torch.allclose(q, expected)

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -1,0 +1,90 @@
+import torch
+import torch.nn as nn
+
+from ACMPC import ActorMPC, CriticTransformer
+from ACMPC import training_loop
+
+
+def f_lin(x, u, dt):
+    return x + dt * u
+
+
+class Policy(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(1, 2)
+
+    def forward(self, x):
+        mu, log_std = self.fc(x).chunk(2, dim=-1)
+        return mu, log_std
+
+
+class TinyEnv:
+    def __init__(self):
+        self.state = torch.zeros(1, dtype=torch.double)
+        self.dt = 0.1
+
+    def reset(self):
+        self.state = torch.zeros(1, dtype=torch.double)
+        return self.state.clone()
+
+    def step(self, action):
+        action = action.detach()
+        new_state = f_lin(self.state, action, self.dt)
+        reward = -new_state.pow(2).sum().item()
+        self.state = new_state.detach().clone()
+        return new_state.clone(), reward, False
+
+
+def compute_loss(env, actor, critic):
+    states, actions, rewards = training_loop.rollout(env, actor, horizon=5)
+    returns = rewards.flip(0).cumsum(0).flip(0)
+    hist = torch.zeros(1, critic.history_len, actor.nx + actor.nu)
+    pred = torch.zeros(1, critic.pred_horizon, actor.nx + actor.nu)
+    value = critic(states[-1].unsqueeze(0), actions[-1].unsqueeze(0), hist, pred)
+    adv = returns.sum() - value
+    return (-adv + adv.pow(2)).item()
+
+
+def _train_step(env, actor, critic, opt_a, opt_c):
+    states, actions, rewards = training_loop.rollout(env, actor, horizon=5)
+    returns = rewards.flip(0).cumsum(0).flip(0)
+    hist = torch.zeros(1, critic.history_len, actor.nx + actor.nu)
+    pred = torch.zeros(1, critic.pred_horizon, actor.nx + actor.nu)
+    value = critic(states[-1].unsqueeze(0), actions[-1].unsqueeze(0), hist, pred)
+    adv = returns.sum() - value
+
+    actor_loss = -adv
+    critic_loss = adv.pow(2)
+
+    opt_a.zero_grad()
+    actor_loss.backward(retain_graph=True)
+    opt_c.zero_grad()
+    critic_loss.backward()
+    opt_a.step()
+    opt_c.step()
+
+    return (actor_loss + critic_loss).item()
+
+
+def test_training_loop_improves_loss():
+    torch.set_default_dtype(torch.double)
+    torch.manual_seed(0)
+    policy = Policy()
+    actor = ActorMPC(
+        1, 1, horizon=2, dt=0.1, f_dyn=f_lin, policy_net=policy, device="cpu"
+    )
+    critic = CriticTransformer(1, 1, history_len=1, pred_horizon=1)
+    actor.double()
+    critic.double()
+
+    opt_a = torch.optim.Adam(actor.parameters())
+    opt_c = torch.optim.Adam(critic.parameters())
+
+    env = TinyEnv()
+    initial_loss = compute_loss(TinyEnv(), actor, critic)
+    for _ in range(20):
+        _train_step(env, actor, critic, opt_a, opt_c)
+    final_loss = compute_loss(TinyEnv(), actor, critic)
+
+    assert final_loss < initial_loss


### PR DESCRIPTION
## Summary
- test ActorMPC `get_action` for shape and reproducibility
- regression test for `CriticTransformer.forward`
- simple training loop sanity check verifying loss drop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68761e7089688326bfaa918a4e02d814