### PR TITLE
Add Profiler context manager and integrate in training loop

### DIFF
--- a/ACMPC/training_loop.py
+++ b/ACMPC/training_loop.py
@@ -1,6 +1,10 @@
 """Minimal PPO training loop for ActorMPC and CriticTransformer."""
+
 import torch
 import torch.optim as optim
+from contextlib import nullcontext
+
+from utils.profiler import Profiler
 
 from .actor import ActorMPC
 from .critic_transformer import CriticTransformer
@@ -23,26 +27,54 @@ def rollout(env, actor: ActorMPC, horizon: int):
     return torch.stack(states), torch.stack(actions), torch.stack(rewards)
 
 
-def train(env, actor: ActorMPC, critic: CriticTransformer, steps: int = 100):
+def train(
+    env,
+    actor: ActorMPC,
+    critic: CriticTransformer,
+    steps: int = 100,
+    *,
+    profile: bool = False,
+    log_file: str | None = None,
+    track_gpu: bool = False,
+):
     actor_opt = optim.Adam(actor.parameters(), lr=3e-4)
     critic_opt = optim.Adam(critic.parameters(), lr=3e-4)
 
     for _ in range(steps):
-        states, actions, rewards = rollout(env, actor, horizon=10)
-        # simple cumulative reward
-        returns = rewards.flip(0).cumsum(0).flip(0)
-        critic_in_hist = torch.zeros(1, critic.history_len, actor.nx + actor.nu, device=states.device)
-        pred = torch.zeros(1, critic.pred_horizon, actor.nx + actor.nu, device=states.device)
-        values = critic(states[-1].unsqueeze(0), actions[-1].unsqueeze(0), critic_in_hist, pred)
-        advantages = returns.sum() - values
+        ctx = (
+            Profiler(
+                log_file=log_file,
+                track_gpu=track_gpu,
+                batches=1,
+            )
+            if profile
+            else nullcontext()
+        )
+        with ctx:
+            states, actions, rewards = rollout(env, actor, horizon=10)
+            # simple cumulative reward
+            returns = rewards.flip(0).cumsum(0).flip(0)
+            critic_in_hist = torch.zeros(
+                1, critic.history_len, actor.nx + actor.nu, device=states.device
+            )
+            pred = torch.zeros(
+                1, critic.pred_horizon, actor.nx + actor.nu, device=states.device
+            )
+            values = critic(
+                states[-1].unsqueeze(0),
+                actions[-1].unsqueeze(0),
+                critic_in_hist,
+                pred,
+            )
+            advantages = returns.sum() - values
 
-        actor_loss = -advantages
-        critic_loss = advantages.pow(2)
+            actor_loss = -advantages
+            critic_loss = advantages.pow(2)
 
-        actor_opt.zero_grad()
-        actor_loss.backward(retain_graph=True)
-        actor_opt.step()
+            actor_opt.zero_grad()
+            actor_loss.backward(retain_graph=True)
+            actor_opt.step()
 
-        critic_opt.zero_grad()
-        critic_loss.backward()
-        critic_opt.step()
+            critic_opt.zero_grad()
+            critic_loss.backward()
+            critic_opt.step()

--- a/utils/profiler.py
+++ b/utils/profiler.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import time
+from contextlib import ContextDecorator
+from typing import Optional
+
+import torch
+
+
+class Profiler(ContextDecorator):
+    """Simple context manager for timing code blocks and tracking GPU memory."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        log_file: Optional[str] = None,
+        track_gpu: bool = False,
+        batches: int | None = None,
+    ) -> None:
+        self.enabled = enabled
+        self.log_file = log_file
+        self.track_gpu = track_gpu
+        self.batches = batches
+        self.start_time: float | None = None
+        self.start_mem: int | None = None
+
+    def __enter__(self) -> "Profiler":
+        if self.enabled:
+            if self.track_gpu and torch.cuda.is_available():
+                torch.cuda.reset_peak_memory_stats()
+                self.start_mem = torch.cuda.memory_allocated()
+            self.start_time = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if not self.enabled:
+            return False
+        end_time = time.perf_counter()
+        elapsed = end_time - (self.start_time or end_time)
+        parts = [f"Elapsed {elapsed:.4f}s"]
+        if self.batches is not None and elapsed > 0:
+            throughput = self.batches / elapsed
+            parts.append(f"Throughput {throughput:.2f} batches/s")
+        if self.track_gpu and torch.cuda.is_available():
+            peak = torch.cuda.max_memory_allocated() - (self.start_mem or 0)
+            parts.append(f"GPU peak {peak / 1024 ** 2:.2f} MiB")
+        msg = " | ".join(parts)
+        if self.log_file:
+            with open(self.log_file, "a", encoding="utf-8") as f:
+                f.write(msg + "\n")
+        else:
+            print(msg)
+        return False


### PR DESCRIPTION
## Summary
- add `Profiler` utility for timing and GPU memory usage
- integrate profiler support in `training_loop.train`

## Testing
- `ruff check utils/profiler.py ACMPC/training_loop.py`
- `black utils/profiler.py ACMPC/training_loop.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68761e8502608326a81b07aa2aa60e29