### PR TITLE
Enhance ActorMPC and add unit tests

### DIFF
--- a/ACMPC/__init__.py
+++ b/ACMPC/__init__.py
@@ -1,4 +1,5 @@
 from .actor import ActorMPC
 from .critic_transformer import CriticTransformer
+from . import training_loop
 
-__all__ = ["ActorMPC", "CriticTransformer"]
+__all__ = ["ActorMPC", "CriticTransformer", "training_loop"]

--- a/ACMPC/actor.py
+++ b/ACMPC/actor.py
@@ -7,7 +7,12 @@ from DifferentialMPC.cost import GeneralQuadCost
 
 
 class ActorMPC(nn.Module):
-    """Differentiable MPC actor with learnable Q and R diagonals."""
+    """Differentiable MPC actor with learnable ``Q`` and ``R`` diagonals.
+
+    Parameters are stored as raw values and passed through ``softplus`` to keep
+    the cost matrices positive definite. The class exposes a :meth:`reset`
+    helper to clear the warm start of the underlying MPC solver.
+    """
 
     def __init__(
         self,
@@ -54,6 +59,11 @@ class ActorMPC(nn.Module):
             device=device,
         )
         self.U_prev: Tensor | None = None
+
+    # ------------------------------------------------------------------
+    def reset(self) -> None:
+        """Clear the stored warm start control sequence."""
+        self.U_prev = None
 
     # ------------------------------------------------------------------
     def _softplus_diag(self, raw: Tensor) -> Tensor:

--- a/ActorCritic/__init__.py
+++ b/ActorCritic/__init__.py
@@ -1,0 +1,3 @@
+from .ActorNet import ActorNet
+
+__all__ = ["ActorNet"]

--- a/tests/test_actor_net.py
+++ b/tests/test_actor_net.py
@@ -1,0 +1,12 @@
+import torch
+from ActorCritic import ActorNet
+
+
+def test_actor_net_output_shapes():
+    torch.set_default_dtype(torch.double)
+    net = ActorNet(nx=2, nu=1)
+    state = torch.randn(4, 2)
+    q, r = net(state)
+    assert q.shape == (4, 2)
+    assert r.shape == (4, 1)
+

--- a/tests/test_actor_reset.py
+++ b/tests/test_actor_reset.py
@@ -1,0 +1,28 @@
+import torch
+import torch.nn as nn
+from ACMPC import ActorMPC
+
+
+def f_lin(x, u, dt):
+    return x + dt * u
+
+
+class DummyPolicy(nn.Module):
+    def __init__(self, nx, nu):
+        super().__init__()
+        self.fc = nn.Linear(nx, 2 * nu)
+
+    def forward(self, x):
+        mu, log_std = self.fc(x).chunk(2, dim=-1)
+        return mu, log_std
+
+
+def test_actor_reset_clears_warm_start():
+    torch.set_default_dtype(torch.double)
+    actor = ActorMPC(1, 1, horizon=3, dt=0.1, f_dyn=f_lin, policy_net=DummyPolicy(1, 1))
+    state = torch.zeros(1)
+    actor(state)
+    assert actor.U_prev is not None
+    actor.reset()
+    assert actor.U_prev is None
+


### PR DESCRIPTION
## Summary
- document ActorMPC and expose a reset helper
- export training utilities and ActorNet via package `__init__` files
- add new unit tests for ActorNet output and ActorMPC reset functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68763c04ea3c8326af5371d38a28a677