### PR TITLE
Implement warm start roll

### DIFF
--- a/ACMPC/actor.py
+++ b/ACMPC/actor.py
@@ -117,7 +117,8 @@ class ActorMPC(nn.Module):
             if U_init.shape[0] != B:
                 U_init = U_init.expand(B, -1, -1)
         if self.U_prev is not None and self.U_prev.shape[0] == B:
-            U_init = self.U_prev
+            U_init = torch.roll(self.U_prev, shifts=-1, dims=1)
+            U_init[:, -1] = 0.0
         u_mpc, _ = self.mpc.solve_step(x, U_init)
         self.U_prev = self.mpc.U_last.detach()
         det = self.deterministic if deterministic is None else deterministic

--- a/DifferentialMPC/controller.py
+++ b/DifferentialMPC/controller.py
@@ -281,7 +281,8 @@ class DifferentiableMPCController(torch.nn.Module):
         x_current = x0
         U_init = torch.zeros(B, H, nu, device=device, dtype=dtype)
         if getattr(self, 'U_prev', None) is not None and self.U_prev.shape[0] == B:
-            U_init = self.U_prev
+            U_init = torch.roll(self.U_prev, shifts=-1, dims=1)
+            U_init[:, -1] = 0.0
 
         xs_list, us_list = [x0], []
 

--- a/tests/test_actor_warm_start.py
+++ b/tests/test_actor_warm_start.py
@@ -1,0 +1,44 @@
+import torch
+import torch.nn as nn
+from ACMPC import ActorMPC
+
+
+def f_lin(x, u, dt):
+    return x + dt * u
+
+
+class DummyPolicy(nn.Module):
+    def __init__(self, nx, nu):
+        super().__init__()
+        self.fc = nn.Linear(nx, 2 * nu)
+
+    def forward(self, x):
+        mu, log_std_raw = self.fc(x).chunk(2, dim=-1)
+        return mu, log_std_raw
+
+
+def test_actor_uses_rolled_warm_start(device):
+    torch.set_default_dtype(torch.double)
+    nx = nu = 1
+    dt = 0.1
+    policy = DummyPolicy(nx, nu).to(device).double()
+    actor = ActorMPC(nx, nu, horizon=3, dt=dt, f_dyn=f_lin, policy_net=policy, device=str(device)).to(device)
+
+    state = torch.zeros(nx, device=device)
+    actor(state)
+    prev = actor.U_prev.clone()
+
+    captured = {}
+    orig_solve_step = actor.mpc.solve_step
+
+    def wrapped(x, U_init, *args, **kwargs):
+        captured['U_init'] = U_init.detach().clone()
+        return orig_solve_step(x, U_init, *args, **kwargs)
+
+    actor.mpc.solve_step = wrapped
+    actor(state)
+
+    expected = torch.roll(prev, shifts=-1, dims=1)
+    expected[:, -1] = 0.0
+    assert torch.allclose(captured['U_init'], expected)
+


### PR DESCRIPTION
## Summary
- roll previous control horizon when warm-starting
- make DifferentialMPC controller use rolled warm start
- test warm-start behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765a1adad883268a101be3861deb3f