### PR TITLE
Update tests for new API

### DIFF
--- a/ACMPC/critic_transformer.py
+++ b/ACMPC/critic_transformer.py
@@ -39,9 +39,17 @@ class CriticTransformer(nn.Module):
         current_state: torch.Tensor,
         current_action: torch.Tensor,
         history: torch.Tensor,
-        predicted: torch.Tensor,
+        predicted: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Return Q-value for given trajectory pieces."""
+        if predicted is None:
+            predicted = torch.zeros(
+                current_state.shape[0],
+                self.pred_horizon,
+                self.token_dim,
+                device=current_state.device,
+                dtype=current_state.dtype,
+            )
         seq = torch.cat(
             [history, torch.cat([current_state, current_action], dim=-1).unsqueeze(1), predicted],
             dim=1,

--- a/tests/test_critic_forward.py
+++ b/tests/test_critic_forward.py
@@ -14,13 +14,12 @@ def test_critic_forward_regression():
             cs = torch.randn(1, 2, dtype=torch.double)
             ca = torch.randn(1, 1, dtype=torch.double)
             hist = torch.randn(1, 3, 3, dtype=torch.double)
-            pred = torch.randn(1, 2, 3, dtype=torch.double)
 
             with torch.no_grad():
-                q = critic(cs, ca, hist, pred)
+                q = critic(cs, ca, hist)
     finally:
         torch.set_default_dtype(prev_dtype)
 
-    expected = torch.tensor([0.010050535202026367], dtype=torch.double)
+    expected = torch.tensor([0.1744472288176528], dtype=torch.double)
     assert q.shape == (1,)
     assert torch.allclose(q, expected)


### PR DESCRIPTION
## Summary
- make `predicted` optional in `CriticTransformer`
- refactor `training_loop.rollout` to also return log-probs
- add `compute_gae_and_returns` helper
- update training loop to use new helpers
- align regression tests with updated APIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765a1ffd988326a51f4b86d7115617