### PR TITLE
Implement GAE-based training loop

### DIFF
--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -37,7 +37,7 @@ class TinyEnv:
 
 
 def compute_loss(env, actor, critic):
-    states, actions, rewards = training_loop.rollout(env, actor, horizon=5)
+    states, actions, rewards, _, _ = training_loop.rollout(env, actor, horizon=5)
     returns = rewards.flip(0).cumsum(0).flip(0)
     hist = torch.zeros(1, critic.history_len, actor.nx + actor.nu)
     pred = torch.zeros(1, critic.pred_horizon, actor.nx + actor.nu)
@@ -47,7 +47,7 @@ def compute_loss(env, actor, critic):
 
 
 def _train_step(env, actor, critic, opt_a, opt_c):
-    states, actions, rewards = training_loop.rollout(env, actor, horizon=5)
+    states, actions, rewards, _, _ = training_loop.rollout(env, actor, horizon=5)
     returns = rewards.flip(0).cumsum(0).flip(0)
     hist = torch.zeros(1, critic.history_len, actor.nx + actor.nu)
     pred = torch.zeros(1, critic.pred_horizon, actor.nx + actor.nu)


### PR DESCRIPTION
## Summary
- extend `rollout` to return log probabilities and final state
- add `compute_gae_and_returns` helper for advantage computation
- update training loop to use new rollout and GAE logic
- adjust unit tests for updated rollout API

## Testing
- `ruff check ACMPC/training_loop.py tests/test_training_loop.py`
- `black ACMPC/training_loop.py tests/test_training_loop.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765a1eeab0832686c27e73ee5b2311