### PR TITLE
Fix style and reorder training order

### DIFF
--- a/ACMPC/training_loop.py
+++ b/ACMPC/training_loop.py
@@ -3,7 +3,7 @@
 import torch
 import torch.optim as optim
 from contextlib import nullcontext
-from importlib import import_module, util as import_util
+from importlib import util as import_util
 from pathlib import Path
 from utils.profiler import Profiler
 


### PR DESCRIPTION
## Summary
- silence ruff F401 in training_loop by dropping unused import
- split actor/critic precision lines in double-integrator demo
- train actor–critic before running baseline MPC in example

## Testing
- `ruff check ACMPC ActorCritic examples/05_double_integrator_ac_vs_baseline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68767583c028832687abd02d20ed4e46